### PR TITLE
Patch React Server Components CVEs

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -16,7 +16,7 @@
         "class-variance-authority": "^0.7.1",
         "clsx": "^2.1.1",
         "lucide-react": "^0.525.0",
-        "next": "15.3.5",
+        "next": "15.3.8",
         "node": "^24.4.0",
         "node-fetch": "^3.3.2",
         "react": "^19.0.0",
@@ -31,7 +31,7 @@
         "@types/react": "^19",
         "@types/react-dom": "^19",
         "eslint": "^9",
-        "eslint-config-next": "15.3.5",
+        "eslint-config-next": "15.3.8",
         "tailwindcss": "^4",
         "tw-animate-css": "^1.3.5",
         "typescript": "^5"
@@ -815,14 +815,14 @@
       }
     },
     "node_modules/@next/env": {
-      "version": "15.3.5",
-      "resolved": "https://registry.npmjs.org/@next/env/-/env-15.3.5.tgz",
-      "integrity": "sha512-7g06v8BUVtN2njAX/r8gheoVffhiKFVt4nx74Tt6G4Hqw9HCLYQVx/GkH2qHvPtAHZaUNZ0VXAa0pQP6v1wk7g=="
+      "version": "15.3.8",
+      "resolved": "https://registry.npmjs.org/@next/env/-/env-15.3.8.tgz",
+      "integrity": "sha512-SAfHg0g91MQVMPioeFeDjE+8UPF3j3BvHjs8ZKJAUz1BG7eMPvfCKOAgNWJ6s1MLNeP6O2InKQRTNblxPWuq+Q=="
     },
     "node_modules/@next/eslint-plugin-next": {
-      "version": "15.3.5",
-      "resolved": "https://registry.npmjs.org/@next/eslint-plugin-next/-/eslint-plugin-next-15.3.5.tgz",
-      "integrity": "sha512-BZwWPGfp9po/rAnJcwUBaM+yT/+yTWIkWdyDwc74G9jcfTrNrmsHe+hXHljV066YNdVs8cxROxX5IgMQGX190w==",
+      "version": "15.3.8",
+      "resolved": "https://registry.npmjs.org/@next/eslint-plugin-next/-/eslint-plugin-next-15.3.8.tgz",
+      "integrity": "sha512-CKpvDZhNXPUjUHmjHddcsqjwj46oQblFms2hr2uA79C0kVTiSXQEQxkawUsDNSofHhTI31IbSeBdVyuk/U1nKw==",
       "dev": true,
       "dependencies": {
         "fast-glob": "3.3.1"
@@ -3491,12 +3491,12 @@
       }
     },
     "node_modules/eslint-config-next": {
-      "version": "15.3.5",
-      "resolved": "https://registry.npmjs.org/eslint-config-next/-/eslint-config-next-15.3.5.tgz",
-      "integrity": "sha512-oQdvnIgP68wh2RlR3MdQpvaJ94R6qEFl+lnu8ZKxPj5fsAHrSF/HlAOZcsimLw3DT6bnEQIUdbZC2Ab6sWyptg==",
+      "version": "15.3.8",
+      "resolved": "https://registry.npmjs.org/eslint-config-next/-/eslint-config-next-15.3.8.tgz",
+      "integrity": "sha512-s/imi0g/LQZsXif8RhlwhgryyqyMhEIMkUL0Yvj0l16ByEAqve4wodS8al+bt+utxf68fgfb1EXlOpuZKqOjlg==",
       "dev": true,
       "dependencies": {
-        "@next/eslint-plugin-next": "15.3.5",
+        "@next/eslint-plugin-next": "15.3.8",
         "@rushstack/eslint-patch": "^1.10.3",
         "@typescript-eslint/eslint-plugin": "^5.4.2 || ^6.0.0 || ^7.0.0 || ^8.0.0",
         "@typescript-eslint/parser": "^5.4.2 || ^6.0.0 || ^7.0.0 || ^8.0.0",
@@ -5254,11 +5254,11 @@
       "dev": true
     },
     "node_modules/next": {
-      "version": "15.3.5",
-      "resolved": "https://registry.npmjs.org/next/-/next-15.3.5.tgz",
-      "integrity": "sha512-RkazLBMMDJSJ4XZQ81kolSpwiCt907l0xcgcpF4xC2Vml6QVcPNXW0NQRwQ80FFtSn7UM52XN0anaw8TEJXaiw==",
+      "version": "15.3.8",
+      "resolved": "https://registry.npmjs.org/next/-/next-15.3.8.tgz",
+      "integrity": "sha512-L+4c5Hlr84fuaNADZbB9+ceRX9/CzwxJ+obXIGHupboB/Q1OLbSUapFs4bO8hnS/E6zV/JDX7sG1QpKVR2bguA==",
       "dependencies": {
-        "@next/env": "15.3.5",
+        "@next/env": "15.3.8",
         "@swc/counter": "0.1.3",
         "@swc/helpers": "0.5.15",
         "busboy": "1.6.0",
@@ -7361,14 +7361,14 @@
       }
     },
     "@next/env": {
-      "version": "15.3.5",
-      "resolved": "https://registry.npmjs.org/@next/env/-/env-15.3.5.tgz",
-      "integrity": "sha512-7g06v8BUVtN2njAX/r8gheoVffhiKFVt4nx74Tt6G4Hqw9HCLYQVx/GkH2qHvPtAHZaUNZ0VXAa0pQP6v1wk7g=="
+      "version": "15.3.8",
+      "resolved": "https://registry.npmjs.org/@next/env/-/env-15.3.8.tgz",
+      "integrity": "sha512-SAfHg0g91MQVMPioeFeDjE+8UPF3j3BvHjs8ZKJAUz1BG7eMPvfCKOAgNWJ6s1MLNeP6O2InKQRTNblxPWuq+Q=="
     },
     "@next/eslint-plugin-next": {
-      "version": "15.3.5",
-      "resolved": "https://registry.npmjs.org/@next/eslint-plugin-next/-/eslint-plugin-next-15.3.5.tgz",
-      "integrity": "sha512-BZwWPGfp9po/rAnJcwUBaM+yT/+yTWIkWdyDwc74G9jcfTrNrmsHe+hXHljV066YNdVs8cxROxX5IgMQGX190w==",
+      "version": "15.3.8",
+      "resolved": "https://registry.npmjs.org/@next/eslint-plugin-next/-/eslint-plugin-next-15.3.8.tgz",
+      "integrity": "sha512-CKpvDZhNXPUjUHmjHddcsqjwj46oQblFms2hr2uA79C0kVTiSXQEQxkawUsDNSofHhTI31IbSeBdVyuk/U1nKw==",
       "dev": true,
       "requires": {
         "fast-glob": "3.3.1"
@@ -9057,12 +9057,12 @@
       }
     },
     "eslint-config-next": {
-      "version": "15.3.5",
-      "resolved": "https://registry.npmjs.org/eslint-config-next/-/eslint-config-next-15.3.5.tgz",
-      "integrity": "sha512-oQdvnIgP68wh2RlR3MdQpvaJ94R6qEFl+lnu8ZKxPj5fsAHrSF/HlAOZcsimLw3DT6bnEQIUdbZC2Ab6sWyptg==",
+      "version": "15.3.8",
+      "resolved": "https://registry.npmjs.org/eslint-config-next/-/eslint-config-next-15.3.8.tgz",
+      "integrity": "sha512-s/imi0g/LQZsXif8RhlwhgryyqyMhEIMkUL0Yvj0l16ByEAqve4wodS8al+bt+utxf68fgfb1EXlOpuZKqOjlg==",
       "dev": true,
       "requires": {
-        "@next/eslint-plugin-next": "15.3.5",
+        "@next/eslint-plugin-next": "15.3.8",
         "@rushstack/eslint-patch": "^1.10.3",
         "@typescript-eslint/eslint-plugin": "^5.4.2 || ^6.0.0 || ^7.0.0 || ^8.0.0",
         "@typescript-eslint/parser": "^5.4.2 || ^6.0.0 || ^7.0.0 || ^8.0.0",
@@ -10213,11 +10213,11 @@
       "dev": true
     },
     "next": {
-      "version": "15.3.5",
-      "resolved": "https://registry.npmjs.org/next/-/next-15.3.5.tgz",
-      "integrity": "sha512-RkazLBMMDJSJ4XZQ81kolSpwiCt907l0xcgcpF4xC2Vml6QVcPNXW0NQRwQ80FFtSn7UM52XN0anaw8TEJXaiw==",
+      "version": "15.3.8",
+      "resolved": "https://registry.npmjs.org/next/-/next-15.3.8.tgz",
+      "integrity": "sha512-L+4c5Hlr84fuaNADZbB9+ceRX9/CzwxJ+obXIGHupboB/Q1OLbSUapFs4bO8hnS/E6zV/JDX7sG1QpKVR2bguA==",
       "requires": {
-        "@next/env": "15.3.5",
+        "@next/env": "15.3.8",
         "@next/swc-darwin-arm64": "15.3.5",
         "@next/swc-darwin-x64": "15.3.5",
         "@next/swc-linux-arm64-gnu": "15.3.5",

--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
     "class-variance-authority": "^0.7.1",
     "clsx": "^2.1.1",
     "lucide-react": "^0.525.0",
-    "next": "15.3.5",
+    "next": "15.3.8",
     "node": "^24.4.0",
     "node-fetch": "^3.3.2",
     "react": "^19.0.0",
@@ -32,7 +32,7 @@
     "@types/react": "^19",
     "@types/react-dom": "^19",
     "eslint": "^9",
-    "eslint-config-next": "15.3.5",
+    "eslint-config-next": "15.3.8",
     "tailwindcss": "^4",
     "tw-animate-css": "^1.3.5",
     "typescript": "^5"


### PR DESCRIPTION
## Summary
- Upgrade Next.js from 15.3.5 to 15.3.8
- Upgrade eslint-config-next to 15.3.8

Addresses React2Shell, CVE-2025-55183, CVE-2025-55184, and CVE-2025-67779.

## Test plan
- [ ] Vercel preview deploy succeeds
- [ ] App loads and game works

Made with [Cursor](https://cursor.com)